### PR TITLE
Use the base name of the odd file to create the compiled version rather than the full path.

### DIFF
--- a/roma2.sh
+++ b/roma2.sh
@@ -13,7 +13,7 @@ makeODD()
     echo "1. expand and simplify ODD "
     if test "x$lang" = "x"
     then
-	 xmllint --xinclude $ODD | saxon -s:- -o:$RESULTS/$ODD.compiled  \
+	 xmllint --xinclude $ODD | saxon -s:- -o:$RESULTS/$ODDBASE.compiled  \
 	    -xsl:$TEIXSLDIR/odds/odd2odd.xsl \
 	    $SELECTEDSCHEMA  \
 	    $LANGUAGE\
@@ -28,7 +28,7 @@ makeODD()
 	    currentDirectory=$H \
 	    useVersionFromTEI=$useVersionFromTEI \
 	    $SOURCE $DEBUG  \
-	    | saxon -o:$RESULTS/$ODD.compiled -s:- -xsl:$TEIXSLDIR/odds/translate-odd.xsl \
+	    | saxon -o:$RESULTS/$ODDBASE.compiled -s:- -xsl:$TEIXSLDIR/odds/translate-odd.xsl \
 	    $DEBUG $LANGUAGE $DOCLANG 
    fi
 }
@@ -36,7 +36,7 @@ makeODD()
 makeRelax() 
 {
     echo "2. make RELAX NG from compiled ODD"
-    saxon   -s:$RESULTS/$ODD.compiled -xsl:$TEIXSLDIR/odds/odd2relax.xsl \
+    saxon   -s:$RESULTS/$ODDBASE.compiled -xsl:$TEIXSLDIR/odds/odd2relax.xsl \
     $PATTERN $DEBUG $LANGUAGE $DOCLANG  $SELECTEDSCHEMA \
 	     parameterize=$parameterize \
              autoGlobal=$AUTOGLOBAL \
@@ -58,7 +58,7 @@ makeXSD()
 makeDTD()
 {
     echo "5. make DTD from compiled ODD"
-    saxon -s:$RESULTS/$ODD.compiled -xsl:$TEIXSLDIR/odds/odd2dtd.xsl \
+    saxon -s:$RESULTS/$ODDBASE.compiled -xsl:$TEIXSLDIR/odds/odd2dtd.xsl \
 	$DEBUG $LANGUAGE $DOCLANG   $SELECTEDSCHEMA \
 	    parameterize=$parameterize \
 	    autoGlobal=$AUTOGLOBAL \
@@ -68,7 +68,7 @@ makeDTD()
 makeSCH()
 {
     echo "8. extract Schematron from compiled ODD"
-    saxon  -s:$RESULTS/$ODD.compiled -xsl:$TEIXSLDIR/odds/extract-sch.xsl \
+    saxon  -s:$RESULTS/$ODDBASE.compiled -xsl:$TEIXSLDIR/odds/extract-sch.xsl \
     $DEBUG $LANGUAGE $DOCLANG   $SELECTEDSCHEMA \
 	> $RESULTS/$schema.sch
 }
@@ -76,7 +76,7 @@ makeSCH()
 makeISOSCH()
 {
     echo "9. extract Schematron from compiled ODD"
-    saxon  -s:$RESULTS/$ODD.compiled -xsl:$TEIXSLDIR/odds/extract-isosch.xsl \
+    saxon  -s:$RESULTS/$ODDBASE.compiled -xsl:$TEIXSLDIR/odds/extract-isosch.xsl \
     $DEBUG $LANGUAGE $DOCLANG   $SELECTEDSCHEMA \
 	> $RESULTS/$schema.isosch
 }
@@ -84,7 +84,7 @@ makeISOSCH()
 makeHTMLDOC() 
 {
     echo "10. make HTML documentation $schema.doc.html "
-    saxon -o:$RESULTS/$schema.doc.html -s:$RESULTS/$ODD.compiled -xsl:$TEIXSLDIR/odds/odd2html.xsl \
+    saxon -o:$RESULTS/$schema.doc.html -s:$RESULTS/$ODDBASE.compiled -xsl:$TEIXSLDIR/odds/odd2html.xsl \
 	$DOCFLAGS  \
 	$DEBUG  $LANGUAGE $DOCLANG autoGlobal=$AUTOGLOBAL \
 	STDOUT=true \
@@ -139,7 +139,7 @@ makeXMLDOC()
 {
     echo "6. make expanded documented ODD $schema.doc.xml "
     saxon -o:$RESULTS/$schema.doc.xml  \
-    -s:$RESULTS/$ODD.compiled -xsl:$TEIXSLDIR/odds/odd2lite.xsl \
+    -s:$RESULTS/$ODDBASE.compiled -xsl:$TEIXSLDIR/odds/odd2lite.xsl \
     $DEBUG $DOCFLAGS  $LANGUAGE $DOCLANG $SOURCE autoGlobal=$AUTOGLOBAL 
 }
 
@@ -242,6 +242,7 @@ while test $# -gt 0; do
   shift
 done
 ODD=${1:?"no schemaspec (i.e., ODD file) supplied; for usage syntax issue $0 --help"}
+ODDBASE=`basename $ODD`
 RESULTS=${2:-RomaResults}
 H=`pwd`/
 D=`date "+%Y-%m-%d %H:%M:%S"`
@@ -344,7 +345,7 @@ then
     fi
 fi
 $dochtml && makeHTMLDOC
-$compile || $debug || rm  $RESULTS/$ODD.compiled
+$compile || $debug || rm  $RESULTS/$ODDBASE.compiled
 test -f subset.xsl && rm subset.xsl
 test -f tei$$.xml && rm tei$$.xml
 D=`date "+%Y-%m-%d %H:%M:%S.%N"`


### PR DESCRIPTION
Previously:

```
$ roma2 --compile long/path/to/somewhere.xml out
```

would create a compiled file at `out/long/path/to/somewhere.xml.compiled`. The modification makes it so that the compiled file is at `out/somewhere.xml.compiled`.

This is also fun:

```
$ cd out
$ roma2 --compile ../myTEI.xml .  # compiled version stored at ../myTEI.xml.compiled
```

I've not noticed a test suite. It would not hurt to inspect, run or test somehow this proposed modification before merging.
