### PR TITLE
Remove calltime pass-by-reference

### DIFF
--- a/roma/docdom.php
+++ b/roma/docdom.php
@@ -99,7 +99,7 @@ class docDom extends domDocument
 	$oTEI = $this->getElementsByTagname( 'TEI' )->item(0);
 	$oBody = $this->getElementsByTagname( 'body' )->item(0);
 
-	$this->m_oRomaDom->getHeader( &$aszHeader );
+	$this->m_oRomaDom->getHeader( $aszHeader );
 #        $aszHeader = $oBody->appendChild( $aszHeader );
 
 	// get selected Modules


### PR DESCRIPTION
- roma/docdom.php (domDocument): Remove calltime pass-by-reference.

The support for calltime pass-by-reference was removed in PHP 5.4.0.
